### PR TITLE
Adds missing TruncationDirection for hf_tokenizers

### DIFF
--- a/src/tokenizers/hf_tokenizers.rs
+++ b/src/tokenizers/hf_tokenizers.rs
@@ -6,8 +6,8 @@ use tokenizers::normalizers::bert::BertNormalizer;
 use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
 use tokenizers::processors::bert::BertProcessing;
 use tokenizers::tokenizer::{
-    EncodeInput, PaddingDirection, PaddingParams, PaddingStrategy, TruncationParams,
-    TruncationStrategy, TruncationDirection
+    EncodeInput, PaddingDirection, PaddingParams, PaddingStrategy, TruncationDirection,
+    TruncationParams, TruncationStrategy,
 };
 use tokenizers::{tokenizer, Model};
 
@@ -65,7 +65,7 @@ impl Tokenizer for HFTokenizer {
             max_length,
             stride,
             strategy,
-            direction
+            direction,
         }));
 
         Ok(Self { tokenizer })

--- a/src/tokenizers/hf_tokenizers.rs
+++ b/src/tokenizers/hf_tokenizers.rs
@@ -7,7 +7,7 @@ use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
 use tokenizers::processors::bert::BertProcessing;
 use tokenizers::tokenizer::{
     EncodeInput, PaddingDirection, PaddingParams, PaddingStrategy, TruncationParams,
-    TruncationStrategy,
+    TruncationStrategy, TruncationDirection
 };
 use tokenizers::{tokenizer, Model};
 
@@ -60,10 +60,12 @@ impl Tokenizer for HFTokenizer {
         let max_length = 128;
         let stride = 0;
         let strategy = TruncationStrategy::LongestFirst;
+        let direction = TruncationDirection::Right;
         tokenizer.with_truncation(Some(TruncationParams {
             max_length,
             stride,
             strategy,
+            direction
         }));
 
         Ok(Self { tokenizer })


### PR DESCRIPTION
Missing field was caused by missing field in TruncationParams in hf_tokenizers and has since been fixed.

Related hf_tokenizers issue: https://github.com/huggingface/tokenizers/commit/4122a33f095e7da48217e19bf9184fefd0506a8e